### PR TITLE
feat!: update HOF signature for state and selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,12 +386,12 @@ console.log(countState.get()); // Print 3
 
 ## Middleware
 
-You can enhance the functionality of state with middleware. Instead of using the `state` export, use the `createState` export from the library. Middleware is a function that receives `set`, `get`, and `subscribe`, and should return a new set function.
+You can enhance the functionality of state with middleware. Instead of using the `state` export, use the `stateBuilder` export from the library. Middleware is a function that receives `set`, `get`, and `subscribe`, and should return a new set function.
 
 ```js
-import { createState } from "reactish-state";
+import { stateBuilder } from "reactish-state";
 
-const state = createState({
+const state = stateBuilder({
   middleware:
     ({ set, get }) =>
     (...args) => {
@@ -420,13 +420,13 @@ filterState.set("COMPLETED"); // Print "New state 'COMPLETED'"
 You can save the state to browser storage using the `persist` middleware.
 
 ```js
-import { createState } from "reactish-state";
+import { stateBuilder } from "reactish-state";
 import { persist } from "reactish-state/middleware";
 
 // Create the persist middleware,
 // optionally provide a `prefix` to prepend to the keys in storage
 const persistMiddleware = persist({ prefix: "myApp-" });
-const state = createState({ middleware: persistMiddleware });
+const state = stateBuilder({ middleware: persistMiddleware });
 
 const countState = state(
   0,
@@ -457,10 +457,10 @@ const persistMiddleware = persist({ getStorage: () => sessionStorage });
 You can update state mutably using the `immer` middleware.
 
 ```js
-import { createState } from "reactish-state";
+import { stateBuilder } from "reactish-state";
 import { immer } from "reactish-state/middleware/immer";
 
-const state = createState({ middleware: immer });
+const state = stateBuilder({ middleware: immer });
 
 let todoId = 1;
 const todos = state([], (set) => ({
@@ -488,10 +488,10 @@ todos.toggle(1);
 This middleware provides integration with the Redux DevTools browser extension. Individual states are combined into a single object in Redux DevTools for easy inspection.
 
 ```js
-import { createState } from "reactish-state";
+import { stateBuilder } from "reactish-state";
 import { reduxDevtools } from "reactish-state/middleware";
 
-const state = createState({ middleware: reduxDevtools({ name: "todoApp" }) });
+const state = stateBuilder({ middleware: reduxDevtools({ name: "todoApp" }) });
 
 const todos = state(
   [],
@@ -523,12 +523,12 @@ const filter = state("ALL", null, { key: "filter" });
 
 ## Using multiple middleware
 
-Middleware is chainable. You can use the `applyMiddleware` utility to chain multiple middleware and pass the result to `createState`.
+Middleware is chainable. You can use the `applyMiddleware` utility to chain multiple middleware and pass the result to `stateBuilder`.
 
 ```js
 import { applyMiddleware } from "reactish-state/middleware";
 
-const state = createState({
+const state = stateBuilder({
   middleware: applyMiddleware([immer, reduxDevtools(), persist()])
 });
 ```
@@ -538,8 +538,8 @@ const state = createState({
 This is naturally achievable thanks to the decentralized state model.
 
 ```js
-const persistState = createState({ middleware: persist() });
-const immerState = createState({ middleware: immer });
+const persistState = stateBuilder({ middleware: persist() });
+const immerState = stateBuilder({ middleware: immer });
 
 const visibilityFilter = persistState("ALL"); // Will be persisted
 const todos = immerState([]); // Can be mutated
@@ -549,12 +549,12 @@ This also eliminates the need to implement a whitelist or blacklist in the persi
 
 ## Plugins
 
-While middleware enhances state, plugins allow you to hook into selectors. The key difference is that plugins don’t return a `set` function, as selectors are read-only. Similarly, you use the `createSelector` export from the library instead of `selector`.
+While middleware enhances state, plugins allow you to hook into selectors. The key difference is that plugins don’t return a `set` function, as selectors are read-only. Similarly, you use the `selectorBuilder` export from the library instead of `selector`.
 
 ```js
-import { state, createSelector } from "reactish-state";
+import { state, selectorBuilder } from "reactish-state";
 
-const selector = createSelector({
+const selector = selectorBuilder({
   plugin: ({ get, subscribe }, config) => {
     subscribe(() => {
       // Log the selector value every time it changes
@@ -587,10 +587,10 @@ Likewise, there is an `applyPlugin` function for applying multiple plugins.
 Individual selectors are combined into a single object in Redux DevTools for easy inspection.
 
 ```js
-import { createSelector } from "reactish-state";
+import { selectorBuilder } from "reactish-state";
 import { reduxDevtools } from "reactish-state/plugin";
 
-const selector = createSelector({ plugin: reduxDevtools() });
+const selector = selectorBuilder({ plugin: reduxDevtools() });
 // Then use the `selector` as usual...
 ```
 

--- a/dist/cjs/index.cjs
+++ b/dist/cjs/index.cjs
@@ -8,10 +8,10 @@ var shim = require('./react/shim.cjs');
 
 
 
-exports.createState = state.createState;
 exports.state = state.state;
-exports.createSelector = selector.createSelector;
+exports.stateBuilder = state.stateBuilder;
 exports.selector = selector.selector;
+exports.selectorBuilder = selector.selectorBuilder;
 exports.useSnapshot = useSnapshot.useSnapshot;
 exports.useSelector = useSelector.useSelector;
 exports.setReactShim = shim.setReactShim;

--- a/dist/cjs/vanilla/selector.cjs
+++ b/dist/cjs/vanilla/selector.cjs
@@ -2,9 +2,7 @@
 
 var utils = require('../utils.cjs');
 
-const createSelector = ({
-  plugin
-} = {}) => (...items) => {
+const selectorBuilder = plugin => (...items) => {
   const length = items.length;
   const cutoff = typeof items[length - 1] === 'function' ? length - 1 : length - 2;
   const selectorFunc = items[cutoff];
@@ -26,7 +24,7 @@ const createSelector = ({
   return selector;
   // Wrap TSelectorMeta in a tuple to prevent conditional type distribution;
 };
-const selector = /*#__PURE__*/createSelector();
+const selector = /*#__PURE__*/selectorBuilder();
 
-exports.createSelector = createSelector;
 exports.selector = selector;
+exports.selectorBuilder = selectorBuilder;

--- a/dist/cjs/vanilla/state.cjs
+++ b/dist/cjs/vanilla/state.cjs
@@ -1,8 +1,6 @@
 'use strict';
 
-const createState = ({
-  middleware
-} = {}) => (initialValue, actionBuilder, metadata) => {
+const stateBuilder = middleware => (initialValue, actionBuilder, metadata) => {
   let value = initialValue;
   const listeners = new Set();
   const get = () => value;
@@ -33,7 +31,7 @@ const createState = ({
   };
   // Wrap TStateMeta in a tuple to prevent conditional type distribution
 };
-const state = /*#__PURE__*/createState();
+const state = /*#__PURE__*/stateBuilder();
 
-exports.createState = createState;
 exports.state = state;
+exports.stateBuilder = stateBuilder;

--- a/dist/esm/index.mjs
+++ b/dist/esm/index.mjs
@@ -1,5 +1,5 @@
-export { createState, state } from './vanilla/state.mjs';
-export { createSelector, selector } from './vanilla/selector.mjs';
+export { state, stateBuilder } from './vanilla/state.mjs';
+export { selector, selectorBuilder } from './vanilla/selector.mjs';
 export { useSnapshot } from './react/useSnapshot.mjs';
 export { useSelector } from './react/useSelector.mjs';
 export { setReactShim } from './react/shim.mjs';

--- a/dist/esm/vanilla/selector.mjs
+++ b/dist/esm/vanilla/selector.mjs
@@ -1,8 +1,6 @@
 import { createSubscriber, getSelectorValues, isEqual } from '../utils.mjs';
 
-const createSelector = ({
-  plugin
-} = {}) => (...items) => {
+const selectorBuilder = plugin => (...items) => {
   const length = items.length;
   const cutoff = typeof items[length - 1] === 'function' ? length - 1 : length - 2;
   const selectorFunc = items[cutoff];
@@ -24,6 +22,6 @@ const createSelector = ({
   return selector;
   // Wrap TSelectorMeta in a tuple to prevent conditional type distribution;
 };
-const selector = /*#__PURE__*/createSelector();
+const selector = /*#__PURE__*/selectorBuilder();
 
-export { createSelector, selector };
+export { selector, selectorBuilder };

--- a/dist/esm/vanilla/state.mjs
+++ b/dist/esm/vanilla/state.mjs
@@ -1,6 +1,4 @@
-const createState = ({
-  middleware
-} = {}) => (initialValue, actionBuilder, metadata) => {
+const stateBuilder = middleware => (initialValue, actionBuilder, metadata) => {
   let value = initialValue;
   const listeners = new Set();
   const get = () => value;
@@ -31,6 +29,6 @@ const createState = ({
   };
   // Wrap TStateMeta in a tuple to prevent conditional type distribution
 };
-const state = /*#__PURE__*/createState();
+const state = /*#__PURE__*/stateBuilder();
 
-export { createState, state };
+export { state, stateBuilder };

--- a/examples/examples/async/store.ts
+++ b/examples/examples/async/store.ts
@@ -1,7 +1,7 @@
-import { createState, selector } from 'reactish-state';
+import { stateBuilder, selector } from 'reactish-state';
 import { reduxDevtools } from 'reactish-state/middleware';
 
-const state = createState({ middleware: reduxDevtools({ name: 'github' }) });
+const state = stateBuilder(reduxDevtools({ name: 'github' }));
 
 type GitHubRepoRes = { id: number; name: string; description: string; stargazers_count: number }[];
 type GitHubUserRes = { name: string; repos_url: string };

--- a/examples/examples/counter/Counter.tsx
+++ b/examples/examples/counter/Counter.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { createState, selector, useSnapshot } from 'reactish-state';
+import { stateBuilder, selector, useSnapshot } from 'reactish-state';
 import { applyMiddleware, persist, reduxDevtools } from 'reactish-state/middleware';
 import styles from './styles.module.css';
 
@@ -16,12 +16,9 @@ const reducer = (state: number, { type, by = 1 }: { type: ActionTypes; by?: numb
 
 const persistMiddleware = persist({ prefix: 'counter-', getStorage: () => sessionStorage });
 
-const counter = createState({
-  middleware: applyMiddleware([
-    reduxDevtools({ name: 'counterApp-state' }),
-    persistMiddleware.middleware
-  ])
-})(
+const counter = stateBuilder(
+  applyMiddleware([reduxDevtools({ name: 'counterApp-state' }), persistMiddleware.middleware])
+)(
   0,
   (set, get) => ({
     // Calling `set` to set a new state

--- a/examples/examples/todo/store.ts
+++ b/examples/examples/todo/store.ts
@@ -1,16 +1,12 @@
-import { createState, createSelector } from 'reactish-state';
+import { stateBuilder, selectorBuilder } from 'reactish-state';
 import { persist, reduxDevtools, applyMiddleware } from 'reactish-state/middleware';
 import { immer } from 'reactish-state/middleware/immer';
 import { reduxDevtools as devtoolsPlugin } from 'reactish-state/plugin';
 
 const persistMiddleware = persist({ prefix: 'todoApp-' });
-const state = createState({
-  middleware: applyMiddleware([
-    reduxDevtools({ name: 'todoApp-state' }),
-    persistMiddleware.middleware,
-    immer
-  ])
-});
+const state = stateBuilder(
+  applyMiddleware([reduxDevtools({ name: 'todoApp-state' }), persistMiddleware.middleware, immer])
+);
 
 interface Todo {
   id: number;
@@ -61,7 +57,7 @@ const getTodoListByFilter = (todoList: Todo[], filter: VisibilityFilter) => {
   }
 };
 
-const selector = createSelector({ plugin: devtoolsPlugin({ name: 'todoApp-selector' }) });
+const selector = selectorBuilder(devtoolsPlugin({ name: 'todoApp-selector' }));
 const visibleTodoList = selector(todoListState, visibilityFilterState, getTodoListByFilter, {
   key: 'visibleTodos'
 });

--- a/examples/next.config.js
+++ b/examples/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  outputFileTracingRoot: __dirname
 };
 
 module.exports = nextConfig;

--- a/src/__tests__/middleware/applyMiddleware.test.ts
+++ b/src/__tests__/middleware/applyMiddleware.test.ts
@@ -1,5 +1,5 @@
 import type { Middleware } from '../../types';
-import { createState } from '../../';
+import { stateBuilder } from '../../';
 import { applyMiddleware } from '../../middleware';
 
 const middleware = jest.fn();
@@ -19,9 +19,7 @@ const middlewares = [
 ];
 
 test('applyMiddleware from left', () => {
-  const state = createState({
-    middleware: applyMiddleware(middlewares)
-  });
+  const state = stateBuilder(applyMiddleware(middlewares));
 
   const power = state('off');
   expect(middleware).toHaveBeenCalledTimes(0);
@@ -33,9 +31,7 @@ test('applyMiddleware from left', () => {
 });
 
 test('applyMiddleware from right', () => {
-  const state = createState({
-    middleware: applyMiddleware(middlewares, { fromRight: true })
-  });
+  const state = stateBuilder(applyMiddleware(middlewares, { fromRight: true }));
 
   const power = state('off');
   expect(middleware).toHaveBeenCalledTimes(0);
@@ -47,13 +43,9 @@ test('applyMiddleware from right', () => {
 });
 
 test('applyMiddleware with state metadata', () => {
-  const state = createState({
-    middleware: applyMiddleware([
-      createMiddleware<string>('mw 1'),
-      undefined,
-      createMiddleware<string>('mw 2')
-    ])
-  });
+  const state = stateBuilder(
+    applyMiddleware([createMiddleware<string>('mw 1'), undefined, createMiddleware<string>('mw 2')])
+  );
 
   const metadata = '230V AC';
   const power = state('off', undefined, metadata);

--- a/src/__tests__/middleware/immer.test.ts
+++ b/src/__tests__/middleware/immer.test.ts
@@ -1,8 +1,8 @@
-import { createState } from '../../';
+import { stateBuilder } from '../../';
 import { immer } from '../../middleware/immer';
 
 test('immer', () => {
-  const state = createState({ middleware: immer });
+  const state = stateBuilder(immer);
 
   const listener = jest.fn();
   const container = state({ deep: { nested: { value: 1 } } });

--- a/src/__tests__/middleware/persist.test.ts
+++ b/src/__tests__/middleware/persist.test.ts
@@ -1,4 +1,4 @@
-import { createState, StateBuilder } from '../../';
+import { stateBuilder, StateBuilder } from '../../';
 import { persist } from '../../middleware';
 
 test('persist should load and save data to storage', () => {
@@ -11,7 +11,7 @@ test('persist should load and save data to storage', () => {
   (global.localStorage as Pick<Storage, 'getItem' | 'setItem'>) = { getItem, setItem };
 
   const { middleware, hydrate } = persist({ prefix: 'cat-' });
-  const state = createState({ middleware });
+  const state = stateBuilder(middleware);
 
   const colour = state('Ginger', null, { key: 'colour', extraProp: 'allowed' });
   const age = state(1, null, { key: 'age' });
@@ -39,7 +39,7 @@ test('persist should load and save data to storage', () => {
 });
 
 test('persist should warn if a key is not provided in config', () => {
-  const state = createState(persist()) as StateBuilder;
+  const state = stateBuilder(persist().middleware) as StateBuilder;
   expect(() => state('no key')).toThrow();
   state('with key', null, { key: 'some-key' });
 });

--- a/src/__tests__/middleware/reduxDevtools.test.ts
+++ b/src/__tests__/middleware/reduxDevtools.test.ts
@@ -1,5 +1,5 @@
 import type {} from '@redux-devtools/extension';
-import { createState, StateBuilder } from '../../';
+import { stateBuilder, StateBuilder } from '../../';
 import { reduxDevtools } from '../../middleware';
 
 describe('reduxDevtools', () => {
@@ -22,7 +22,7 @@ describe('reduxDevtools', () => {
   });
 
   test('should send actions', () => {
-    const state = createState({ middleware: reduxDevtools({ name: 'my-app' }) });
+    const state = stateBuilder(reduxDevtools({ name: 'my-app' }));
     const price = state(0.99, null, { key: 'price' });
     const quantity = state(1, null, { key: 'qty' });
 
@@ -46,7 +46,7 @@ describe('reduxDevtools', () => {
   });
 
   test('should warn if a key is not provided in metadata', () => {
-    const state = createState({ middleware: reduxDevtools() }) as StateBuilder;
+    const state = stateBuilder(reduxDevtools()) as StateBuilder;
     expect(() => state('no key')).toThrow();
     state('with key', null, { key: 'some-key' });
   });

--- a/src/__tests__/plugin/applyMiddleware.test.ts
+++ b/src/__tests__/plugin/applyMiddleware.test.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from '../../types';
-import { state, createSelector } from '../../';
+import { state, selectorBuilder } from '../../';
 import { applyPlugin } from '../../plugin';
 
 const plugin = jest.fn();
@@ -12,9 +12,9 @@ const createPlugin: <TMeta = never>(name: string) => Plugin<TMeta> =
   };
 
 test('applyPlugin without metadata', () => {
-  const selector = createSelector({
-    plugin: applyPlugin([createPlugin('plugin 1'), createPlugin('plugin 2'), undefined])
-  });
+  const selector = selectorBuilder(
+    applyPlugin([createPlugin('plugin 1'), createPlugin('plugin 2'), undefined])
+  );
 
   const count = state(1);
   selector(count, (count) => count * 2);
@@ -27,13 +27,9 @@ test('applyPlugin without metadata', () => {
 });
 
 test('applyPlugin with metadata', () => {
-  const selector = createSelector({
-    plugin: applyPlugin([
-      createPlugin<string>('plugin 1'),
-      createPlugin<string>('plugin 2'),
-      undefined
-    ])
-  });
+  const selector = selectorBuilder(
+    applyPlugin([createPlugin<string>('plugin 1'), createPlugin<string>('plugin 2'), undefined])
+  );
 
   const count = state(1);
   selector(count, (count) => count * 2, 'double');

--- a/src/__tests__/plugin/reduxDevtools.test.ts
+++ b/src/__tests__/plugin/reduxDevtools.test.ts
@@ -1,4 +1,4 @@
-import { state, createSelector, SelectorBuilder } from '../../';
+import { state, selectorBuilder, SelectorBuilder } from '../../';
 import { reduxDevtools } from '../../plugin';
 
 describe('reduxDevtools', () => {
@@ -20,7 +20,7 @@ describe('reduxDevtools', () => {
   });
 
   test('should merge selector and send to the dev tool', () => {
-    const selector = createSelector({ plugin: reduxDevtools({ name: 'my-app' }) });
+    const selector = selectorBuilder(reduxDevtools({ name: 'my-app' }));
     const count = state(1);
     selector(count, (count) => count * 2, { key: 'double' });
     selector(count, (count) => count * 3, { key: 'triple' });
@@ -35,7 +35,7 @@ describe('reduxDevtools', () => {
   });
 
   test('should warn if a key is not provided in metadata', () => {
-    const selector = createSelector({ plugin: reduxDevtools() }) as SelectorBuilder;
+    const selector = selectorBuilder(reduxDevtools()) as SelectorBuilder;
     expect(() => selector(state(1), (count) => count * 2)).toThrow();
   });
 });

--- a/src/__tests__/vanilla/selector.test.ts
+++ b/src/__tests__/vanilla/selector.test.ts
@@ -1,5 +1,5 @@
 import { state } from '../../vanilla/state';
-import { selector, createSelector, Metadata } from '../../';
+import { selector, selectorBuilder, Metadata } from '../../';
 
 test('selector should update when the base state has changed', () => {
   const price = state(7);
@@ -61,14 +61,12 @@ test('selector should return cached result when base state has not changed', () 
 
 test('selector can be enhanced with plugin', () => {
   const plugin = jest.fn();
-  const selector = createSelector<Metadata>({
-    plugin: ({ get, subscribe, meta }) => {
-      const onChange = () => {
-        plugin(get(), meta().key);
-      };
-      onChange();
-      subscribe(onChange);
-    }
+  const selector = selectorBuilder<Metadata>(({ get, subscribe, meta }) => {
+    const onChange = () => {
+      plugin(get(), meta().key);
+    };
+    onChange();
+    subscribe(onChange);
   });
 
   const count = state(1);

--- a/src/__tests__/vanilla/state.test.ts
+++ b/src/__tests__/vanilla/state.test.ts
@@ -1,4 +1,4 @@
-import { state, createState, Metadata } from '../../';
+import { state, stateBuilder, Metadata } from '../../';
 
 test('function overloads and type correctness', () => {
   const s1 = state('s1');
@@ -174,13 +174,9 @@ test('state can bind actions', () => {
 
 test('state can be enhanced with middleware', () => {
   const middleware = jest.fn();
-  const state = createState<Metadata>({
-    middleware:
-      ({ set, get, meta }) =>
-      (...arg) => {
-        set(...arg);
-        middleware(get(), meta().key);
-      }
+  const state = stateBuilder<Metadata>(({ set, get, meta }) => (...arg) => {
+    set(...arg);
+    middleware(get(), meta().key);
   });
 
   const key = 'count';

--- a/src/vanilla/selector.ts
+++ b/src/vanilla/selector.ts
@@ -8,9 +8,7 @@ import type {
 } from '../types';
 import { isEqual, createSubscriber, getSelectorValues } from '../utils';
 
-const createSelector = <TSelectorMeta = never>({
-  plugin
-}: { plugin?: Plugin<TSelectorMeta> } = {}) =>
+const selectorBuilder = <TSelectorMeta = never>(plugin?: Plugin<TSelectorMeta>) =>
   (<TArray extends SelectorArray, TValue, TMeta extends TSelectorMeta>(...items: unknown[]) => {
     const length = items.length;
     const cutoff = typeof items[length - 1] === 'function' ? length - 1 : length - 2;
@@ -36,6 +34,6 @@ const createSelector = <TSelectorMeta = never>({
     // Wrap TSelectorMeta in a tuple to prevent conditional type distribution;
   }) as [TSelectorMeta] extends [never] ? SelectorBuilder : SelectorBuilderWithMeta<TSelectorMeta>;
 
-const selector = createSelector();
+const selector = selectorBuilder();
 
-export { selector, createSelector };
+export { selector, selectorBuilder };

--- a/src/vanilla/state.ts
+++ b/src/vanilla/state.ts
@@ -9,9 +9,7 @@ import type {
   Middleware
 } from '../types';
 
-const createState = <TStateMeta = never>({
-  middleware
-}: { middleware?: Middleware<TStateMeta> } = {}) =>
+const stateBuilder = <TStateMeta = never>(middleware?: Middleware<TStateMeta>) =>
   (<TValue, TAction, TMeta extends TStateMeta, TContext>(
     initialValue: TValue,
     actionBuilder: ActionBuilder<TValue, TAction, TContext> | null | undefined,
@@ -50,6 +48,6 @@ const createState = <TStateMeta = never>({
     // Wrap TStateMeta in a tuple to prevent conditional type distribution
   }) as [TStateMeta] extends [never] ? StateBuilder : StateBuilderWithMeta<TStateMeta>;
 
-const state = createState();
+const state = stateBuilder();
 
-export { state, createState };
+export { state, stateBuilder };

--- a/types/vanilla/selector.d.ts
+++ b/types/vanilla/selector.d.ts
@@ -1,6 +1,4 @@
 import type { Plugin, SelectorBuilder, SelectorBuilderWithMeta } from '../types';
-declare const createSelector: <TSelectorMeta = never>({ plugin }?: {
-    plugin?: Plugin<TSelectorMeta>;
-}) => [TSelectorMeta] extends [never] ? SelectorBuilder : SelectorBuilderWithMeta<TSelectorMeta>;
+declare const selectorBuilder: <TSelectorMeta = never>(plugin?: Plugin<TSelectorMeta>) => [TSelectorMeta] extends [never] ? SelectorBuilder : SelectorBuilderWithMeta<TSelectorMeta>;
 declare const selector: SelectorBuilder;
-export { selector, createSelector };
+export { selector, selectorBuilder };

--- a/types/vanilla/state.d.ts
+++ b/types/vanilla/state.d.ts
@@ -1,6 +1,4 @@
 import type { StateBuilder, StateBuilderWithMeta, Middleware } from '../types';
-declare const createState: <TStateMeta = never>({ middleware }?: {
-    middleware?: Middleware<TStateMeta>;
-}) => [TStateMeta] extends [never] ? StateBuilder : StateBuilderWithMeta<TStateMeta>;
+declare const stateBuilder: <TStateMeta = never>(middleware?: Middleware<TStateMeta>) => [TStateMeta] extends [never] ? StateBuilder : StateBuilderWithMeta<TStateMeta>;
 declare const state: StateBuilder;
-export { state, createState };
+export { state, stateBuilder };


### PR DESCRIPTION
### Breaking Changes
- Rename `createState` to `stateBuilder`, and `createSelector` to `selectorBuilder`
- Unwrap middleware and plugin parameters (pass directly instead of inside an object)